### PR TITLE
[Update] ExceptionHandler추가

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -146,6 +146,13 @@
 		    <scope>test</scope>
 		</dependency>
 		
+		<!-- Mockito 테스트 코드-->
+		<dependency>
+		    <groupId>org.mockito</groupId>
+		    <artifactId>mockito-core</artifactId>
+		    <version>3.12.4</version>
+		    <scope>test</scope>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/src/main/java/com/web/app/exception/ExceptionManager.java
+++ b/src/main/java/com/web/app/exception/ExceptionManager.java
@@ -1,0 +1,21 @@
+package com.web.app.exception;
+
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RestControllerAdvice
+public class ExceptionManager {
+	
+	@ExceptionHandler(DataIntegrityViolationException.class)
+	public ResponseEntity<?> DataIntegrityViolationExceptionHandler(DataIntegrityViolationException e){
+		log.error("DataIntegrityViolationException occurred: {}", e.getMessage());
+		return ResponseEntity.status(HttpStatus.CONFLICT)
+				.body(e.getMessage());
+	}
+}

--- a/src/main/java/com/web/app/service/MemberServiceImpl.java
+++ b/src/main/java/com/web/app/service/MemberServiceImpl.java
@@ -1,5 +1,6 @@
 package com.web.app.service;
 
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.core.Authentication;
@@ -29,7 +30,11 @@ public class MemberServiceImpl implements MemberService{
 	@Transactional
 	public void postMemberSignUp(MemberSignUpRequsetDTO memberSignUpRequsetDTO) {
 		Member member = createNewMemberAndEncodePassword(memberSignUpRequsetDTO);
-		memberRepository.postMemberSignUp(member);
+		try {
+			memberRepository.postMemberSignUp(member);
+		} catch (DataIntegrityViolationException e) {
+			throw new DataIntegrityViolationException("아이디 혹은 이메일이 사용중입니다.");
+		}
 	}
 	
 	private Member createNewMemberAndEncodePassword(MemberSignUpRequsetDTO memberSignUpRequsetDTO) {

--- a/src/main/resources/templates/Member_signUp.html
+++ b/src/main/resources/templates/Member_signUp.html
@@ -39,10 +39,11 @@ function validation() {
     	data: JSON.stringify(user),
     	success:function(data){
     		console.log("회원가입성공");
+    		alert("회원가입이 성공적으로 완료되었습니다.");
     		window.location.href = "/login";
     	},
     	error: function(e){
-    		alert("시스템에 문제가 발생했습니다. 다시 시도해주세요");
+    		alert(e.responseText);
     		window.location.href="/member/signUp";
     	}
     	
@@ -91,7 +92,7 @@ function checkEmailDuplication(){
 		type: "get",
 		url: "/member/signUp/validation/email="+email,
 		success: function(data) {
-			if(data.email == 0){
+			if(data == 0){
 				alert("사용 가능한 이메일 입니다.");
 				$("#email").attr("data-checked","true");
 				$("#email").prop("readOnly",true);

--- a/src/test/java/com/web/app/BoardTest.java
+++ b/src/test/java/com/web/app/BoardTest.java
@@ -1,28 +1,39 @@
 package com.web.app;
 
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.verify;
+
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.transaction.annotation.Transactional;
+import org.springframework.dao.DataIntegrityViolationException;
 
 import com.web.app.dto.BoardDTO;
 import com.web.app.dto.Criteria;
+import com.web.app.dto.MemberSignUpRequsetDTO;
 import com.web.app.dto.PageDTO;
 import com.web.app.repository.BoardRepository;
+import com.web.app.repository.MemberRepository;
+import com.web.app.service.MemberService;
 
-import lombok.extern.log4j.Log4j;
 import lombok.extern.slf4j.Slf4j;
-import oracle.jdbc.clio.annotations.Trace;
 
 @SpringBootTest
 @Slf4j
 public class BoardTest {
 	@Autowired
 	private BoardRepository boardRepository;
+	@Autowired
+	private MemberService memberService;
+	@Autowired
+	private MemberRepository memberRepository;
 	
 	@Test
 	public void testPaging() {
@@ -59,6 +70,7 @@ public class BoardTest {
 	}
 	
 	@Test
+	@DisplayName("검색 및 페이징 테스트")
 	public void testSearchPaging() {
 		Criteria criteria = new Criteria();
 		criteria.setType("T");
@@ -67,9 +79,14 @@ public class BoardTest {
 		list.forEach(board -> log.info(board.toString()));
 	}
 	
-	@Transactional
 	@Test
+	@DisplayName("회원가입 실패 - 아이디/이메일 중복")
 	public void duplicationTest() {
-		
+	    //Given
+	    MemberSignUpRequsetDTO dto = new MemberSignUpRequsetDTO("test", "1234", "test@naver.com", "user");
+	    //When
+	    Throwable thrown = assertThrows(DataIntegrityViolationException.class, () -> memberService.postMemberSignUp(dto));
+	    //Then
+	    assertThat(thrown.getMessage()).isEqualTo("아이디 혹은 이메일이 사용중입니다.");
 	}
 }


### PR DESCRIPTION
1. ExceptionManage를 추가
현재 회원가입 로직은 아이디 중복체크, 이메일 중복체크를 해야만 가입이 되도록 진행된다.

하지만 만약
A유저가 아이디가 중복이 없음을 확인하고 이메일을 중복체크를 하는 도중,
B유저가 같은 아이디로 중복체크를 하면 사용가능한 아이디로 응답을 받게된다.
A유저가 회원가입을 완료하고 B유저가 회원가입을 하된다면??

기존에는 아무런 처리를 하지 않고 있었지만, 이번에 ExceptionManager를 추가해서 해당 예외가 발생하면, 예외를 잡아 사용자 커스텀 예외로 응답해서 경고창을 띄우도록 수정했다.